### PR TITLE
relax torch version check to 2.1+ for checkpointers

### DIFF
--- a/bytecheckpoint/checkpointer/ddp_checkpointer.py
+++ b/bytecheckpoint/checkpointer/ddp_checkpointer.py
@@ -87,8 +87,8 @@ class DDPCheckpointer(BaseCheckpointer):
         logger.info("Start save function call. ")
 
         # Check version.
-        assert torch.__version__.strip() < "2.6.0" and torch.__version__.strip() >= "2.1.0", (
-            "ByteCheckpoint now only support torch version from 2.1 to 2.5"
+        assert "2.1.0" <= torch.__version__.strip(), (
+            "ByteCheckpoint now only support torch version from 2.1 and above"
         )
         # Check role.
         if role and role not in SUPPORTED_ROLE_SUFFIX_TYPES:

--- a/bytecheckpoint/checkpointer/fsdp2_checkpointer.py
+++ b/bytecheckpoint/checkpointer/fsdp2_checkpointer.py
@@ -91,8 +91,8 @@ class FSDP2Checkpointer(BaseCheckpointer):
             logger.warning("Unsupported role %s, will use default role instead", role)
             role = SUPPORTED_ROLE_SUFFIX_TYPES[DEFAULT_STR]
         # Check version.
-        assert "2.1.0" <= torch.__version__.strip() and torch.__version__.strip() < "2.6.0", (
-            "ByteCheckpoint now only support torch version from 2.1 to 2.5"
+        assert "2.1.0" <= torch.__version__.strip(), (
+            "ByteCheckpoint now only support torch version from 2.1 and above"
         )
         # Check supported components.
         cls.check_supported_components(checkpoint_state, FSDP_SUPPORTED_TYPES)

--- a/bytecheckpoint/checkpointer/fsdp_checkpointer.py
+++ b/bytecheckpoint/checkpointer/fsdp_checkpointer.py
@@ -102,8 +102,8 @@ class FSDPCheckpointer(BaseCheckpointer):
             logger.warning("Unsupported role %s, will use default role instead", role)
             role = SUPPORTED_ROLE_SUFFIX_TYPES[DEFAULT_STR]
         # Check version.
-        assert "2.1.0" <= torch.__version__.strip() and torch.__version__.strip() < "2.6.0", (
-            "ByteCheckpoint now only support torch version from 2.1 to 2.5"
+        assert "2.1.0" <= torch.__version__.strip(), (
+            "ByteCheckpoint now only support torch version from 2.1 and above"
         )
         # Check supported components.
         cls.check_supported_components(checkpoint_state, FSDP_SUPPORTED_TYPES)


### PR DESCRIPTION
Allow newer torch releases by removing the 2.5 upper bound in DDP/FSDP/FSDP2 checks.

P.S. Aligns with [https://github.com/ByteDance-Seed/ByteCheckpoint/pull/15](https://github.com/ByteDance-Seed/ByteCheckpoint/pull/url) expectations.